### PR TITLE
Added dockerfile to allow for easy installation of plugin

### DIFF
--- a/require-ldap.dockerfile
+++ b/require-ldap.dockerfile
@@ -1,0 +1,14 @@
+FROM composer:latest as composer
+
+FROM php:7.2-fpm-alpine
+COPY --from=composer /usr/bin/composer /usr/bin/composer
+
+ARG INSTALL_PATH=/app
+
+RUN apk --no-cache add composer git openldap-dev libldap
+RUN docker-php-ext-install ldap
+
+WORKDIR ${INSTALL_PATH}
+VOLUME ${INSTALL_PATH}
+
+CMD composer require tituspijean/flarum-ext-auth-ldap


### PR DESCRIPTION
Assuming docker is installed:
### build
`docker build -f ./require-ldap.dockerfile -t require-ldap`
### run
(linux) `docker run --rm -it -v $PWD:/app require-ldap:1`
(windows) `docker run --rm -it -v ${pwd}:/app require-ldap:1`